### PR TITLE
fix passing range configuration to a servo

### DIFF
--- a/lib/artoo/drivers/servo.rb
+++ b/lib/artoo/drivers/servo.rb
@@ -13,7 +13,9 @@ module Artoo
         super
 
         @current_angle = 0
-        @angle_range = params[:range].nil? ? Range.new(30,150) : Range.new(params[:range][:min],params[:range][:max])
+        additional_params = params.fetch(:additional_params, {})
+        min_max = additional_params.fetch(:range, {:min => 30, :max => 150})
+        @angle_range = Range.new(min_max[:min],min_max[:max])
       end
 
       # Moves to specified angle

--- a/test/drivers/servo_test.rb
+++ b/test/drivers/servo_test.rb
@@ -46,4 +46,19 @@ describe Artoo::Drivers::Servo do
     @servo.send(:safe_angle, 90).must_equal 90
     @servo.send(:safe_angle, 180).must_equal 150
   end
+
+  describe "custom range" do
+    before do
+      @servo = Artoo::Drivers::Servo.new(
+        :parent => @device,
+        :additional_params => {
+          :range => {:min => 10, :max => 170}})
+    end
+
+    it 'Servo#safe_angle' do
+      @servo.send(:safe_angle,0).must_equal 10
+      @servo.send(:safe_angle,90).must_equal 90
+      @servo.send(:safe_angle,180).must_equal 170
+    end
+  end
 end


### PR DESCRIPTION
I could not find a way to pass a custom safe angle range to a servo. I experimented with code like this:

``` ruby
device :servo, :driver => :servo, :pin => 1, :range => {:min => 0, :max => 180}
```

But the params I specify get nested under <code>:additional_params</code> like this:

``` ruby
{
  :parent=> #<Device @id=2165082460, @name='name', @driver='driver'>,
  :additional_params=> {
    :name=> :servo,
    :driver=> :servo,
    :pin=> 1,
    :range=> {:min=>0, :max=>180},
    :parent=>#<Robot 2164657460>
  }
}
```

I followed the pattern found in https://github.com/hybridgroup/artoo-gpio/blob/master/lib/artoo/drivers/motor.rb#L14
