### PR TITLE
Adds Relay Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.rvmrc
+.rbx
+pkg
+Gemfile.lock

--- a/lib/artoo/drivers/relay.rb
+++ b/lib/artoo/drivers/relay.rb
@@ -1,0 +1,72 @@
+require 'artoo/drivers/driver'
+
+module Artoo
+  module Drivers
+    # The Relay driver behaviors
+    class Relay < Driver
+
+      COMMANDS = [:on, :off, :toggle,
+                  :on?, :off?, :invert, :status].freeze
+
+      def initialize(params = {})
+        @is_on = false
+        aditional_params = params[:aditional_params] || {}
+        @is_inverted = aditional_params[:invert] || false
+        super
+      end
+
+      # @return [Boolean] True if on
+      def on?
+        @is_on
+      end
+
+      # @return [Boolean] True if off
+      def off?
+        (not on?)
+      end
+
+      # Sets relay to on
+      def on
+        change_state(pin, state(:high))
+        @is_on = true
+        true
+      end
+
+      # Sets relay to off
+      def off
+        change_state(pin, state(:low))
+        @is_on = false
+        true
+      end
+
+      # Toggle status
+      # @example on > off, off > on
+      def toggle
+        on? ? off : on
+      end
+      
+      # @return relay's state
+      def status
+        read_state(pin)
+      end
+
+      private
+      def change_state(pin, level)
+        connection.digital_write(pin, level)
+      end
+      
+      def read_state(pin)
+        connection.digital_read(pin)
+      end
+      
+      def state(value)
+        if @is_inverted
+          [:low, :high].reject{|e| e == value}.first
+        else
+          value
+        end
+      end
+      
+    end
+  end
+end

--- a/test/drivers/relay_test.rb
+++ b/test/drivers/relay_test.rb
@@ -1,0 +1,84 @@
+require File.expand_path(File.dirname(__FILE__) + "/../test_helper")
+require 'artoo/drivers/relay'
+
+describe Artoo::Drivers::Relay do
+  before do
+    @device = mock('device')
+    @pin = 7
+    @device.stubs(:pin).returns(@pin)
+    @relay = Artoo::Drivers::Relay.new(:parent => @device)
+    @connection = mock('connection')
+    @device.stubs(:connection).returns(@connection)
+  end
+
+  describe 'state switching' do
+    describe '#on' do
+      it 'must turn the relay on' do
+        @connection.expects(:digital_write).with(@pin, :high)
+        @relay.on
+      end
+    end
+
+    describe '#off' do
+      it 'must turn the relay off' do
+        @connection.expects(:digital_write).with(@pin, :low)
+        @relay.off
+      end
+    end
+  end
+
+  describe 'state checking' do
+
+    before do
+      @relay.stubs(:change_state)
+    end
+
+    describe '#on?' do
+      it 'must return true if relay is on' do
+        @relay.on
+        @relay.on?.must_equal true
+      end
+
+      it 'must return false if relay is off' do
+        @relay.off
+        @relay.on?.must_equal false
+      end
+    end
+
+    describe '#off?' do
+      it 'must return true if relay is off' do
+        @relay.off
+        @relay.off?.must_equal true
+      end
+
+      it 'must return false if relay is on' do
+        @relay.on
+        @relay.off?.must_equal false
+      end
+    end
+  end
+
+  describe '#toggle' do
+    it 'must toggle the state of the relay' do
+      @relay.stubs(:pin_state_on_board).returns(false)
+      @connection.stubs(:set_pin_mode)
+      @connection.stubs(:digital_write)
+      @relay.off?.must_equal true
+      @relay.toggle
+      @relay.on?.must_equal true
+      @relay.toggle
+      @relay.off?.must_equal true
+    end
+  end
+
+  describe '#commands' do
+    it 'must contain all the necessary commands' do
+      @relay.commands.must_include :on
+      @relay.commands.must_include :off
+      @relay.commands.must_include :toggle
+      @relay.commands.must_include :on?
+      @relay.commands.must_include :off?
+      @relay.commands.must_include :invert
+    end
+  end
+end


### PR DESCRIPTION
Ability to switch on or more relays on or off.

Added an invert flag for relays which use `:low` for ON and `:high` for OFF.
The default is invert: false meaning that `:high` ON and `:low` is OFF.

Usage is either `relay.on`/`relay.off` or `relay.toggle`
